### PR TITLE
Adds validation only endpoint filter

### DIFF
--- a/.github/workflows/publlish-package-workflow.yml
+++ b/.github/workflows/publlish-package-workflow.yml
@@ -34,7 +34,13 @@ jobs:
         run: dotnet test -c Release --no-restore --no-build
 
       - name: Pack
-        run: dotnet pack -p:PackageVersion=${{ github.event.inputs.version }} -c Release -o ./.nupkgs
+        run: |
+          dotnet pack \
+            -p:PackageVersion=${{ github.event.inputs.version }} \
+            -p:IncludeSymbols=true \
+            -p:SymbolPackageFormat=snupkg \
+            -c Release \
+            -o ./.nupkgs
 
       - name: Publish NuGet
         run: |

--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,7 @@
 *.userosscache
 *.sln.docstates
 .idea/
+.DS_Store
 
 # User-specific files (MonoDevelop/Xamarin Studio)
 *.userprefs

--- a/README.md
+++ b/README.md
@@ -125,6 +125,20 @@ builder.Services.AddEndpointValidation<Program>(options =>
 });
 ```
 
+#### Validate Only Header
+
+This sets the header that the middleware will look for to determine if the request should only be validated. If the header is present, the request will be validated, but the endpoint will not be executed:
+
+```csharp
+builder.Services.AddEndpointValidation<Program>(options =>
+{
+    // the default value is "x-validate-only"
+    options.ValidateOnlyHeader = "x-custom-validate-only";
+});
+```
+
+> See the [Validation Only](#validation-only) section for more information.
+
 ## Validation
 
 The package provides several features and helpers for validating incoming requests:
@@ -321,6 +335,50 @@ If validation fails, a `ValidationProblem` result is returned which produces a `
     "Age": ["The Age field must be between 1 and 100."]
   }
 }
+```
+
+## Validation Only
+
+If you want to validate a request without executing the endpoint, you can use the `WithValidateOnly` endpoint filter in combination with the optional `ValidateOnlyHeader`:
+
+```csharp
+app.MapPost("/test-body", ([FromBody] TestRecord test) => test).WithValidateOnly();
+```
+
+This filter looks for the configured `ValidateOnlyHeader` in the request and returns and intercepts the request between validation and endpoint execution, returning a `202 Accepted` response if the request is valid.
+
+> The header is optional, and must be present and set to `true` for the filter to take effect.
+
+Request:
+```http request
+POST /test-body
+Content-Type: application/json
+x-validate-only: true
+
+{
+  "name": "John",
+  "age": 30
+}
+```
+
+Response:
+```json
+{
+  "isValid": true,
+  "message": "Request was validated but not processed.",
+  "timestamp": "2024-11-12T14:30:26.3682090+00:00"
+}
+```
+
+### Custom Validate Only Header
+
+The default header is `x-validate-only`, but this can be configured when registering the validation services:
+
+```csharp
+builder.Services.AddEndpointValidation<Program>(options =>
+{
+    options.ValidateOnlyHeader = "x-custom-validate-only";
+});
 ```
 
 ## FAQs

--- a/README.md
+++ b/README.md
@@ -384,3 +384,7 @@ builder.Services.AddEndpointValidation<Program>(options =>
 ## FAQs
 
 You can check out more docs and some FAQs [here](./docs)
+
+## Examples
+
+You can find some examples in the [examples](./examples) folder.

--- a/examples/Example/Endpoints/Query/Query.http
+++ b/examples/Example/Endpoints/Query/Query.http
@@ -13,7 +13,7 @@ Accept: application/json
 # with-query-string : 200 OK - valid with optional
 GET {{HostAddress}}/with-query-string/
     ?requiredString=value
-    &optionalRangedInt=optional
+    &optionalString=optional
     &requiredRangedInt=1
     &optionalRangedInt=6
 Accept: application/json
@@ -37,22 +37,4 @@ Accept: application/json
 GET {{HostAddress}}/with-query-string/
     ?requiredString=value
     &requiredRangedInt=0
-Accept: application/json
-
-###
-
-# with-query-group : 200 OK - valid
-GET {{HostAddress}}/with-query-group/
-    ?name=bilbo
-    &age=111
-    &other=abc
-Accept: application/json
-
-###
-
-# with-query-group : 400 BAD REQUEST - age out of range
-GET {{HostAddress}}/with-query-group/
-    ?name=bilbo
-    &age=200
-    &other=abc
 Accept: application/json

--- a/examples/Example/Endpoints/ValidateOnly/EndpointWithValidateOnly.cs
+++ b/examples/Example/Endpoints/ValidateOnly/EndpointWithValidateOnly.cs
@@ -1,13 +1,19 @@
-namespace Example.Endpoints.Body;
+namespace Example.Endpoints.ValidateOnly;
 
+using A3.MinimalApiValidation;
 using FluentValidation;
 using Microsoft.AspNetCore.Mvc;
 
-public class EndpointWithBody : IEndpoint
+public class EndpointWithValidateOnly : IEndpoint
 {
     public static void Add(IEndpointRouteBuilder app)
     {
-        app.MapPost("with-body", ([FromBody] TestRecord body) => TypedResults.Ok(body));
+        app.MapPost("with-validate-only", (
+            [FromQuery] string requiredString,
+            [FromHeader(Name = "x-required-header")] string requiredHeader,
+            [FromBody] TestRecord body
+        ) => Results.StatusCode(500))
+        .WithValidateOnly();
     }
 
     public record TestRecord(string Name, int Age);

--- a/examples/Example/Endpoints/ValidateOnly/ValidateOnly.http
+++ b/examples/Example/Endpoints/ValidateOnly/ValidateOnly.http
@@ -1,0 +1,53 @@
+@HostAddress = http://localhost:5053
+
+# with-validate-only : 202 ACCEPTED - valid
+POST {{HostAddress}}/with-validate-only?requiredString=value
+Accept: application/json
+Content-Type: application/json
+x-validate-only: true
+x-required-header: value2
+
+{
+    "name": "John",
+    "age": 32
+}
+
+###
+
+# with-validate-only : 400 BAD REQUEST - missing query parameter
+POST {{HostAddress}}/with-validate-only
+Accept: application/json
+Content-Type: application/json
+x-validate-only: true
+x-required-header: value2
+
+{
+  "name": "John",
+  "age": 32
+}
+
+###
+
+# with-validate-only : 400 BAD REQUEST - missing header
+POST {{HostAddress}}/with-validate-only?requiredString=value
+Accept: application/json
+Content-Type: application/json
+x-validate-only: true
+
+{
+  "name": "John",
+  "age": 32
+}
+
+###
+
+# with-validate-only : 400 BAD REQUEST - missing name
+POST {{HostAddress}}/with-validate-only?requiredString=value
+Accept: application/json
+Content-Type: application/json
+x-validate-only: true
+x-required-header: value2
+
+{
+  "age": 32
+}

--- a/src/A3.MinimalApiValidation/EndpointValidatorExtensions.cs
+++ b/src/A3.MinimalApiValidation/EndpointValidatorExtensions.cs
@@ -98,4 +98,23 @@ public static class EndpointValidationExtensions
 
         return builder;
     }
+
+    /// <summary>
+    /// Ads an endpoint filter that will allow validation of the request, but not
+    /// execute the endpoint if the validate only header is present.
+    /// <para>A 202 Accepted response is returned if the request is valid.</para>
+    /// <para>The default header is `x-validate-only`, but can be overridden in the <see cref="EndpointValidatorOptions"/>.</para>
+    /// </summary>
+    /// <param name="builder">The route handler builder.</param>
+    /// <returns>The route handler builder.</returns>
+    public static RouteHandlerBuilder WithValidateOnly(this RouteHandlerBuilder builder)
+    {
+        builder
+            .AddEndpointFilter<ValidateOnlyFilter>()
+            .Produces<ValidateOnlyResponse>(
+                statusCode: StatusCodes.Status202Accepted,
+                contentType: "application/json");
+
+        return builder;
+    }
 }

--- a/src/A3.MinimalApiValidation/EndpointValidatorExtensions.cs
+++ b/src/A3.MinimalApiValidation/EndpointValidatorExtensions.cs
@@ -100,7 +100,7 @@ public static class EndpointValidationExtensions
     }
 
     /// <summary>
-    /// Ads an endpoint filter that will allow validation of the request, but not
+    /// Adds an endpoint filter that will allow validation of the request, but not
     /// execute the endpoint if the validate only header is present.
     /// <para>A 202 Accepted response is returned if the request is valid.</para>
     /// <para>The default header is `x-validate-only`, but can be overridden in the <see cref="EndpointValidatorOptions"/>.</para>

--- a/src/A3.MinimalApiValidation/EndpointValidatorOptions.cs
+++ b/src/A3.MinimalApiValidation/EndpointValidatorOptions.cs
@@ -32,4 +32,10 @@ public class EndpointValidatorOptions
     /// <para>The default value is <c>false</c></para>
     /// </summary>
     public bool PreferExplicitRequestModelValidation { get; set; }
+    
+    /// <summary>
+    /// Used to set the name for the validate only header for use with the <see cref="ValidateOnlyFilter"/>.
+    /// <para>The default value is 'x-validate-only'.</para>
+    /// </summary>
+    public string ValidateOnlyHeader { get; set; } = "x-validate-only";
 }

--- a/src/A3.MinimalApiValidation/Internal/Filter/ValidateOnlyFilter.cs
+++ b/src/A3.MinimalApiValidation/Internal/Filter/ValidateOnlyFilter.cs
@@ -1,0 +1,55 @@
+namespace A3.MinimalApiValidation.Internal.Filter;
+
+using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.DependencyInjection;
+
+internal class ValidateOnlyFilter : IEndpointFilter
+{
+    public async ValueTask<object?> InvokeAsync(
+        EndpointFilterInvocationContext context,
+        EndpointFilterDelegate next)
+    {
+        var timestamp = context.HttpContext.RequestServices.GetService<TimeProvider>()?.GetUtcNow() ?? DateTime.UtcNow;
+        
+        var options = context.HttpContext.RequestServices.GetService<EndpointValidatorOptions>()
+            ?? EndpointValidatorOptions.Default;
+
+        var logger = context.HttpContext.GetLogger<ValidateOnlyFilter>();
+        
+        if (context.HttpContext.Request.Headers.TryGetValue(options.ValidateOnlyHeader, out var validateOnly)
+            && validateOnly.ToString().Equals("true", StringComparison.CurrentCultureIgnoreCase))
+        {
+            logger.Debug_ValidateOnlyHeaderSet();
+            
+            return Results.Accepted(null, new ValidateOnlyResponse
+            (
+                IsValid: true,
+                Message: "Request was validated but not processed.",
+                Timestamp: timestamp.ToString("O")
+            ));
+        }
+
+        return await next(context);
+    }
+}
+
+public record ValidateOnlyResponse(bool IsValid, string Message, string Timestamp)
+{
+    /// <summary>
+    /// A value indicating whether or not the request passed validation.
+    /// </summary>
+    /// <example>true</example>
+    public bool IsValid { get; } = IsValid;
+
+    /// <summary>
+    /// A message indicating that the result was validated but not processed.
+    /// </summary>
+    /// <example>Request was validated but not processed.</example>
+    public string Message { get; } = Message;
+
+    /// <summary>
+    /// UTC timestamp of when the request was validated.
+    /// </summary>
+    /// <example>2024-07-04T08:45:42.9763790Z</example>
+    public string Timestamp { get; } = Timestamp;
+}

--- a/src/A3.MinimalApiValidation/Internal/LogMessages.cs
+++ b/src/A3.MinimalApiValidation/Internal/LogMessages.cs
@@ -47,4 +47,7 @@ internal static partial class LogMessages
 
     [LoggerMessage(LogLevel.Debug, "Handling header parameter: {Name}.", EventId = 0)]
     internal static partial void Debug_HandlingHeaderParameter(this ILogger logger, string name);
+    
+    [LoggerMessage(LogLevel.Debug, "Validate only header was set, returning validate only response", EventId = 0)]
+    internal static partial void Debug_ValidateOnlyHeaderSet(this ILogger logger);
 }

--- a/test/A3.MinimalApiValidation.Tests/ApiIntegrationTests/ValidateOnlyFilter/Body/AutoValidationDisabled.cs
+++ b/test/A3.MinimalApiValidation.Tests/ApiIntegrationTests/ValidateOnlyFilter/Body/AutoValidationDisabled.cs
@@ -1,0 +1,58 @@
+namespace A3.MinimalApiValidation.Tests.ApiIntegrationTests.ValidateOnlyFilter.Body;
+
+using System.Net;
+using System.Text;
+using System.Text.Json;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.Testing;
+using Microsoft.AspNetCore.Routing;
+
+public class AutoValidationDisabled : TestBase
+{
+    public AutoValidationDisabled(WebApplicationFactory<Program> factory) : base(factory)
+    {
+    }
+
+    protected override void ConfigureOptions(EndpointValidatorOptions options)
+    {
+        options.PreferExplicitRequestModelValidation = true;
+    }
+
+    protected override void AddTestEndpoint(IEndpointRouteBuilder app)
+    {
+        app.MapPost(Path, ([FromBody] TestRecord body) => Results.StatusCode(500)).WithValidateOnly();
+    }
+
+    [Theory]
+    [InlineData("John", 0)]
+    [InlineData("John", 101)]
+    [InlineData(null, 30)]
+    [InlineData("", 30)]
+    [InlineData(" ", 30)]
+    [InlineData("John", 30)]
+    public async Task returns_accepted_for_any_values_when_auto_validation_is_disabled(string? name, int age)
+    {
+        // Arrange
+        var body = JsonSerializer.Serialize(new
+        {
+            name = name,
+            age = age,
+        });
+        
+        var request = new HttpRequestMessage(
+            method: HttpMethod.Post,
+            requestUri: Path
+        );
+        request.Headers.TryAddWithoutValidation("x-validate-only", "true");
+        request.Content = new StringContent(body, Encoding.UTF8, "application/json");
+
+        // Act
+        var response = await Client.SendAsync(request);
+
+        // Assert
+        response.EnsureSuccessStatusCode();
+        Assert.Equal(HttpStatusCode.Accepted, response.StatusCode);
+    }
+}

--- a/test/A3.MinimalApiValidation.Tests/ApiIntegrationTests/ValidateOnlyFilter/Body/AutoValidationDisabledWithExplicitValidate.cs
+++ b/test/A3.MinimalApiValidation.Tests/ApiIntegrationTests/ValidateOnlyFilter/Body/AutoValidationDisabledWithExplicitValidate.cs
@@ -1,0 +1,140 @@
+namespace A3.MinimalApiValidation.Tests.ApiIntegrationTests.ValidateOnlyFilter.Body;
+
+using System.Net;
+using System.Text;
+using System.Text.Json;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.Testing;
+using Microsoft.AspNetCore.Routing;
+
+public class AutoValidationDisabledWithExplicitValidate : TestBase
+{
+    public AutoValidationDisabledWithExplicitValidate(WebApplicationFactory<Program> factory) : base(factory)
+    {
+    }
+
+    protected override void ConfigureOptions(EndpointValidatorOptions options)
+    {
+        options.PreferExplicitRequestModelValidation = true;
+    }
+
+    protected override void AddTestEndpoint(IEndpointRouteBuilder app)
+    {
+        app
+            .MapPost(Path, ([FromBody] TestRecord body) => Results.StatusCode(500))
+            .Validate<TestRecord>()
+            .WithValidateOnly();
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData(" ")]
+    public async Task returns_bad_request_for_invalid_name(string? name)
+    {
+        // Arrange
+        var body = JsonSerializer.Serialize(new
+        {
+            name = name,
+            age = 30,
+        });
+        
+        var request = new HttpRequestMessage(
+            method: HttpMethod.Post,
+            requestUri: Path
+        );
+        request.Headers.TryAddWithoutValidation("x-validate-only", "true");
+        request.Content = new StringContent(body, Encoding.UTF8, "application/json");
+
+        // Act
+        var response = await Client.SendAsync(request);
+
+        // Assert
+        await response.EnsureErrorFor("name");
+    }
+
+    [Theory]
+    [InlineData(-1)]
+    [InlineData(0)]
+    [InlineData(101)]
+    [InlineData(1001)]
+    public async Task returns_bad_request_for_invalid_age(int age)
+    {
+        // Arrange
+        var body = JsonSerializer.Serialize(new
+        {
+            name = "John",
+            age = age,
+        });
+        
+        var request = new HttpRequestMessage(
+            method: HttpMethod.Post,
+            requestUri: Path
+        );
+        request.Headers.TryAddWithoutValidation("x-validate-only", "true");
+        request.Content = new StringContent(body, Encoding.UTF8, "application/json");
+
+        // Act
+        var response = await Client.SendAsync(request);
+
+        // Assert
+        await response.EnsureErrorFor("age");
+    }
+
+    [Fact]
+    public async Task returns_bad_request_for_invalid_name_and_age()
+    {
+        // Arrange
+        var body = JsonSerializer.Serialize(new
+        {
+            name = "",
+            age = 0,
+        });
+        
+        var request = new HttpRequestMessage(
+            method: HttpMethod.Post,
+            requestUri: Path
+        );
+        request.Headers.TryAddWithoutValidation("x-validate-only", "true");
+        request.Content = new StringContent(body, Encoding.UTF8, "application/json");
+
+        // Act
+        var response = await Client.SendAsync(request);
+
+        // Assert
+        await response.EnsureErrorFor("name", "age");
+    }
+
+    [Theory]
+    [InlineData("John", 1)]
+    [InlineData("John", 30)]
+    [InlineData("John", 99)]
+    [InlineData("Jane", 1)]
+    [InlineData("Jane", 30)]
+    [InlineData("Jane", 99)]
+    public async Task returns_accepted_for_valid_values(string name, int age)
+    {
+        // Arrange
+        var body = JsonSerializer.Serialize(new
+        {
+            name = name,
+            age = age,
+        });
+        
+        var request = new HttpRequestMessage(
+            method: HttpMethod.Post,
+            requestUri: Path
+        );
+        request.Headers.TryAddWithoutValidation("x-validate-only", "true");
+        request.Content = new StringContent(body, Encoding.UTF8, "application/json");
+
+        // Act
+        var response = await Client.SendAsync(request);
+
+        // Assert
+        response.EnsureSuccessStatusCode();
+        Assert.Equal(HttpStatusCode.Accepted, response.StatusCode);
+    }
+}

--- a/test/A3.MinimalApiValidation.Tests/ApiIntegrationTests/ValidateOnlyFilter/Body/AutoValidationDisabledWithExplicitValidateAnnotations.cs
+++ b/test/A3.MinimalApiValidation.Tests/ApiIntegrationTests/ValidateOnlyFilter/Body/AutoValidationDisabledWithExplicitValidateAnnotations.cs
@@ -1,0 +1,142 @@
+namespace A3.MinimalApiValidation.Tests.ApiIntegrationTests.ValidateOnlyFilter.Body;
+
+using System.Net;
+using System.Text;
+using System.Text.Json;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.Testing;
+using Microsoft.AspNetCore.Routing;
+
+public class AutoValidationDisabledWithExplicitValidateAnnotations : TestBase
+{
+    public AutoValidationDisabledWithExplicitValidateAnnotations(WebApplicationFactory<Program> factory) : base(factory)
+    {
+    }
+
+    protected override bool RegisterValidator => false;
+
+    protected override void ConfigureOptions(EndpointValidatorOptions options)
+    {
+        options.PreferExplicitRequestModelValidation = true;
+        options.FallbackToDataAnnotations = true;
+    }
+
+    protected override void AddTestEndpoint(IEndpointRouteBuilder app)
+    {
+        app.MapPost(Path, ([FromBody] TestRecordAnnotated body) => Results.StatusCode(500))
+            .Validate<TestRecordAnnotated>()
+            .WithValidateOnly();
+    }
+    
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData(" ")]
+    public async Task returns_bad_request_for_invalid_name(string? name)
+    {
+        // Arrange
+        var body = JsonSerializer.Serialize(new
+        {
+            name = name,
+            age = 30,
+        });
+        
+        var request = new HttpRequestMessage(
+            method: HttpMethod.Post,
+            requestUri: Path
+        );
+        request.Headers.TryAddWithoutValidation("x-validate-only", "true");
+        request.Content = new StringContent(body, Encoding.UTF8, "application/json");
+
+        // Act
+        var response = await Client.SendAsync(request);
+
+        // Assert
+        await response.EnsureErrorFor("name");
+    }
+    
+    [Theory]
+    [InlineData(-1)]
+    [InlineData(0)]
+    [InlineData(101)]
+    [InlineData(1001)]
+    public async Task returns_bad_request_for_invalid_age(int age)
+    {
+        // Arrange
+        var body = JsonSerializer.Serialize(new
+        {
+            name = "John",
+            age = age,
+        });
+        
+        var request = new HttpRequestMessage(
+            method: HttpMethod.Post,
+            requestUri: Path
+        );
+        request.Headers.TryAddWithoutValidation("x-validate-only", "true");
+        request.Content = new StringContent(body, Encoding.UTF8, "application/json");
+
+        // Act
+        var response = await Client.SendAsync(request);
+
+        // Assert
+        await response.EnsureErrorFor("age");
+    }
+    
+    [Fact]
+    public async Task returns_bad_request_for_invalid_name_and_age()
+    {
+        // Arrange
+        var body = JsonSerializer.Serialize(new
+        {
+            name = "",
+            age = 0,
+        });
+        
+        var request = new HttpRequestMessage(
+            method: HttpMethod.Post,
+            requestUri: Path
+        );
+        request.Headers.TryAddWithoutValidation("x-validate-only", "true");
+        request.Content = new StringContent(body, Encoding.UTF8, "application/json");
+
+        // Act
+        var response = await Client.SendAsync(request);
+
+        // Assert
+        await response.EnsureErrorFor("name", "age");
+    }
+    
+    [Theory]
+    [InlineData("John", 1)]
+    [InlineData("John", 30)]
+    [InlineData("John", 99)]
+    [InlineData("Jane", 1)]
+    [InlineData("Jane", 30)]
+    [InlineData("Jane", 99)]
+    public async Task returns_accepted_for_valid_values(string name, int age)
+    {
+        // Arrange
+        var body = JsonSerializer.Serialize(new
+        {
+            name = name,
+            age = age,
+        });
+        
+        var request = new HttpRequestMessage(
+            method: HttpMethod.Post,
+            requestUri: Path
+        );
+        request.Headers.TryAddWithoutValidation("x-validate-only", "true");
+        request.Content = new StringContent(body, Encoding.UTF8, "application/json");
+
+        // Act
+        var response = await Client.SendAsync(request);
+
+        // Assert
+        response.EnsureSuccessStatusCode();
+        Assert.Equal(HttpStatusCode.Accepted, response.StatusCode);
+    }
+}

--- a/test/A3.MinimalApiValidation.Tests/ApiIntegrationTests/ValidateOnlyFilter/Body/DataAnnotationsValidatorFallback.cs
+++ b/test/A3.MinimalApiValidation.Tests/ApiIntegrationTests/ValidateOnlyFilter/Body/DataAnnotationsValidatorFallback.cs
@@ -1,0 +1,139 @@
+namespace A3.MinimalApiValidation.Tests.ApiIntegrationTests.ValidateOnlyFilter.Body;
+
+using System.Net;
+using System.Text;
+using System.Text.Json;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.Testing;
+using Microsoft.AspNetCore.Routing;
+
+public class DataAnnotationsValidatorFallback : TestBase
+{
+    public DataAnnotationsValidatorFallback(WebApplicationFactory<Program> factory) : base(factory)
+    {
+    }
+    
+    protected override bool RegisterValidator => false;
+
+    protected override void ConfigureOptions(EndpointValidatorOptions options)
+    {
+        options.FallbackToDataAnnotations = true;
+    }
+
+    protected override void AddTestEndpoint(IEndpointRouteBuilder app)
+    {
+        app.MapPost(Path, ([FromBody] TestRecordAnnotated body) => Results.StatusCode(500)).WithValidateOnly();
+    }
+    
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData(" ")]
+    public async Task returns_bad_request_for_invalid_name(string? name)
+    {
+        // Arrange
+        var body = JsonSerializer.Serialize(new
+        {
+            name = name,
+            age = 30,
+        });
+        
+        var request = new HttpRequestMessage(
+            method: HttpMethod.Post,
+            requestUri: Path
+        );
+        request.Headers.TryAddWithoutValidation("x-validate-only", "true");
+        request.Content = new StringContent(body, Encoding.UTF8, "application/json");
+
+        // Act
+        var response = await Client.SendAsync(request);
+
+        // Assert
+        await response.EnsureErrorFor("name");
+    }
+    
+    [Theory]
+    [InlineData(-1)]
+    [InlineData(0)]
+    [InlineData(101)]
+    [InlineData(1001)]
+    public async Task returns_bad_request_for_invalid_age(int age)
+    {
+        // Arrange
+        var body = JsonSerializer.Serialize(new
+        {
+            name = "John",
+            age = age,
+        });
+        
+        var request = new HttpRequestMessage(
+            method: HttpMethod.Post,
+            requestUri: Path
+        );
+        request.Headers.TryAddWithoutValidation("x-validate-only", "true");
+        request.Content = new StringContent(body, Encoding.UTF8, "application/json");
+
+        // Act
+        var response = await Client.SendAsync(request);
+
+        // Assert
+        await response.EnsureErrorFor("age");
+    }
+    
+    [Fact]
+    public async Task returns_bad_request_for_invalid_name_and_age()
+    {
+        // Arrange
+        var body = JsonSerializer.Serialize(new
+        {
+            name = "",
+            age = 0,
+        });
+        
+        var request = new HttpRequestMessage(
+            method: HttpMethod.Post,
+            requestUri: Path
+        );
+        request.Headers.TryAddWithoutValidation("x-validate-only", "true");
+        request.Content = new StringContent(body, Encoding.UTF8, "application/json");
+
+        // Act
+        var response = await Client.SendAsync(request);
+
+        // Assert
+        await response.EnsureErrorFor("name", "age");
+    }
+    
+    [Theory]
+    [InlineData("John", 1)]
+    [InlineData("John", 30)]
+    [InlineData("John", 99)]
+    [InlineData("Jane", 1)]
+    [InlineData("Jane", 30)]
+    [InlineData("Jane", 99)]
+    public async Task returns_accepted_for_valid_values(string name, int age)
+    {
+        // Arrange
+        var body = JsonSerializer.Serialize(new
+        {
+            name = name,
+            age = age,
+        });
+        
+        var request = new HttpRequestMessage(
+            method: HttpMethod.Post,
+            requestUri: Path
+        );
+        request.Headers.TryAddWithoutValidation("x-validate-only", "true");
+        request.Content = new StringContent(body, Encoding.UTF8, "application/json");
+
+        // Act
+        var response = await Client.SendAsync(request);
+
+        // Assert
+        response.EnsureSuccessStatusCode();
+        Assert.Equal(HttpStatusCode.Accepted, response.StatusCode);
+    }
+}

--- a/test/A3.MinimalApiValidation.Tests/ApiIntegrationTests/ValidateOnlyFilter/Body/FluentValidatorRegistered.cs
+++ b/test/A3.MinimalApiValidation.Tests/ApiIntegrationTests/ValidateOnlyFilter/Body/FluentValidatorRegistered.cs
@@ -1,0 +1,132 @@
+namespace A3.MinimalApiValidation.Tests.ApiIntegrationTests.ValidateOnlyFilter.Body;
+
+using System.Net;
+using System.Text;
+using System.Text.Json;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.Testing;
+using Microsoft.AspNetCore.Routing;
+
+public class FluentValidatorRegistered : TestBase
+{
+    public FluentValidatorRegistered(WebApplicationFactory<Program> factory) : base(factory)
+    {
+    }
+
+    protected override void AddTestEndpoint(IEndpointRouteBuilder app)
+    {
+        app.MapPost(Path, ([FromBody] TestRecord body) => Results.StatusCode(500)).WithValidateOnly();
+    }
+    
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData(" ")]
+    public async Task returns_bad_request_for_invalid_name(string? name)
+    {
+        // Arrange
+        var body = JsonSerializer.Serialize(new
+        {
+            name = name,
+            age = 30,
+        });
+        
+        var request = new HttpRequestMessage(
+            method: HttpMethod.Post,
+            requestUri: Path
+        );
+        request.Headers.TryAddWithoutValidation("x-validate-only", "true");
+        request.Content = new StringContent(body, Encoding.UTF8, "application/json");
+
+        // Act
+        var response = await Client.SendAsync(request);
+
+        // Assert
+        await response.EnsureErrorFor("name");
+    }
+    
+    [Theory]
+    [InlineData(-1)]
+    [InlineData(0)]
+    [InlineData(101)]
+    [InlineData(1001)]
+    public async Task returns_bad_request_for_invalid_age(int age)
+    {
+        // Arrange
+        var body = JsonSerializer.Serialize(new
+        {
+            name = "John",
+            age = age,
+        });
+        
+        var request = new HttpRequestMessage(
+            method: HttpMethod.Post,
+            requestUri: Path
+        );
+        request.Headers.TryAddWithoutValidation("x-validate-only", "true");
+        request.Content = new StringContent(body, Encoding.UTF8, "application/json");
+
+        // Act
+        var response = await Client.SendAsync(request);
+
+        // Assert
+        await response.EnsureErrorFor("age");
+    }
+    
+    [Fact]
+    public async Task returns_bad_request_for_invalid_name_and_age()
+    {
+        // Arrange
+        var body = JsonSerializer.Serialize(new
+        {
+            name = "",
+            age = 0,
+        });
+        
+        var request = new HttpRequestMessage(
+            method: HttpMethod.Post,
+            requestUri: Path
+        );
+        request.Headers.TryAddWithoutValidation("x-validate-only", "true");
+        request.Content = new StringContent(body, Encoding.UTF8, "application/json");
+
+        // Act
+        var response = await Client.SendAsync(request);
+
+        // Assert
+        await response.EnsureErrorFor("name", "age");
+    }
+    
+    [Theory]
+    [InlineData("John", 1)]
+    [InlineData("John", 30)]
+    [InlineData("John", 99)]
+    [InlineData("Jane", 1)]
+    [InlineData("Jane", 30)]
+    [InlineData("Jane", 99)]
+    public async Task returns_accepted_for_valid_values(string name, int age)
+    {
+        // Arrange
+        var body = JsonSerializer.Serialize(new
+        {
+            name = name,
+            age = age,
+        });
+        
+        var request = new HttpRequestMessage(
+            method: HttpMethod.Post,
+            requestUri: Path
+        );
+        request.Headers.TryAddWithoutValidation("x-validate-only", "true");
+        request.Content = new StringContent(body, Encoding.UTF8, "application/json");
+
+        // Act
+        var response = await Client.SendAsync(request);
+
+        // Assert
+        response.EnsureSuccessStatusCode();
+        Assert.Equal(HttpStatusCode.Accepted, response.StatusCode);
+    }
+}

--- a/test/A3.MinimalApiValidation.Tests/ApiIntegrationTests/ValidateOnlyFilter/Body/NoValidatorRegistered.cs
+++ b/test/A3.MinimalApiValidation.Tests/ApiIntegrationTests/ValidateOnlyFilter/Body/NoValidatorRegistered.cs
@@ -1,0 +1,55 @@
+namespace A3.MinimalApiValidation.Tests.ApiIntegrationTests.ValidateOnlyFilter.Body;
+
+using System.Net;
+using System.Text;
+using System.Text.Json;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.Testing;
+using Microsoft.AspNetCore.Routing;
+
+public class NoValidatorRegistered : TestBase
+{
+    public NoValidatorRegistered(WebApplicationFactory<Program> factory) : base(factory)
+    {
+    }
+    
+    protected override bool RegisterValidator => false;
+
+    protected override void AddTestEndpoint(IEndpointRouteBuilder app)
+    {
+        app.MapPost(Path, ([FromBody] TestRecord body) => Results.StatusCode(500)).WithValidateOnly();
+    }
+
+    [Theory]
+    [InlineData("John", 0)]
+    [InlineData("John", 101)]
+    [InlineData(null, 30)]
+    [InlineData("", 30)]
+    [InlineData(" ", 30)]
+    [InlineData("John", 30)]
+    public async Task returns_accepted_for_any_values_when_no_validator_is_registered(string? name, int age)
+    {
+        // Arrange
+        var body = JsonSerializer.Serialize(new
+        {
+            name = name,
+            age = age,
+        });
+        
+        var request = new HttpRequestMessage(
+            method: HttpMethod.Post,
+            requestUri: Path
+        );
+        request.Headers.TryAddWithoutValidation("x-validate-only", "true");
+        request.Content = new StringContent(body, Encoding.UTF8, "application/json");
+
+        // Act
+        var response = await Client.SendAsync(request);
+
+        // Assert
+        response.EnsureSuccessStatusCode();
+        Assert.Equal(HttpStatusCode.Accepted, response.StatusCode);
+    }
+}

--- a/test/A3.MinimalApiValidation.Tests/ApiIntegrationTests/ValidateOnlyFilter/Header/RequiredDateTimeHeader.cs
+++ b/test/A3.MinimalApiValidation.Tests/ApiIntegrationTests/ValidateOnlyFilter/Header/RequiredDateTimeHeader.cs
@@ -1,0 +1,80 @@
+namespace A3.MinimalApiValidation.Tests.ApiIntegrationTests.ValidateOnlyFilter.Header;
+
+using System.Net;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.Testing;
+using Microsoft.AspNetCore.Routing;
+
+public class RequiredDateTimeHeader : TestBase
+{
+    public RequiredDateTimeHeader(WebApplicationFactory<Program> factory) : base(factory)
+    {
+    }
+
+    protected override void AddTestEndpoint(IEndpointRouteBuilder app)
+    {
+        app.MapGet(Path, ([FromHeader(Name = "x-required")] DateTime header) => Results.StatusCode(500)).WithValidateOnly();
+    }
+
+    [Theory]
+    [InlineData("2022-02-22")]
+    [InlineData("2022-02-22T22:22:22")]
+    [InlineData("2022-02-22T22:22:22Z")]
+    [InlineData("2022-02-22T22:22:22.123")]
+    public async Task returns_accepted_when_required_header_is_valid(string header)
+    {
+        // Arrange
+        var request = new HttpRequestMessage(
+            method: HttpMethod.Get,
+            requestUri: Path
+        );
+        request.Headers.TryAddWithoutValidation("x-required", header);
+        request.Headers.TryAddWithoutValidation("x-validate-only", "true");
+
+        // Act
+        var response = await Client.SendAsync(request);
+
+        // Assert
+        response.EnsureSuccessStatusCode();
+        Assert.Equal(HttpStatusCode.Accepted, response.StatusCode);
+    }
+
+    [Fact]
+    public async Task returns_bad_request_when_required_header_is_missing()
+    {
+        // Arrange
+        var request = new HttpRequestMessage(
+            method: HttpMethod.Get,
+            requestUri: Path
+        );
+        request.Headers.TryAddWithoutValidation("x-validate-only", "true");
+
+        // Act
+        var response = await Client.SendAsync(request);
+
+        // Assert
+        await response.EnsureErrorFor("x-required");
+    }
+
+    [Theory]
+    [InlineData("not-a-date")]
+    [InlineData("123-456")]
+    public async Task returns_bad_request_when_required_header_is_not_a_date(string header)
+    {
+        // Arrange
+        var request = new HttpRequestMessage(
+            method: HttpMethod.Get,
+            requestUri: Path
+        );
+        request.Headers.TryAddWithoutValidation("x-required", header);
+        request.Headers.TryAddWithoutValidation("x-validate-only", "true");
+
+        // Act
+        var response = await Client.SendAsync(request);
+
+        // Assert
+        await response.EnsureErrorFor("x-required");
+    }
+}

--- a/test/A3.MinimalApiValidation.Tests/ApiIntegrationTests/ValidateOnlyFilter/Header/RequiredGuidHeader.cs
+++ b/test/A3.MinimalApiValidation.Tests/ApiIntegrationTests/ValidateOnlyFilter/Header/RequiredGuidHeader.cs
@@ -1,0 +1,77 @@
+namespace A3.MinimalApiValidation.Tests.ApiIntegrationTests.ValidateOnlyFilter.Header;
+
+using System.Net;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.Testing;
+using Microsoft.AspNetCore.Routing;
+
+public class RequiredGuidHeader : TestBase
+{
+    public RequiredGuidHeader(WebApplicationFactory<Program> factory) : base(factory)
+    {
+    }
+
+    protected override void AddTestEndpoint(IEndpointRouteBuilder app)
+    {
+        app.MapGet(Path, ([FromHeader(Name = "x-required")] Guid header) => Results.StatusCode(500)).WithValidateOnly();
+    }
+
+    [Fact]
+    public async Task returns_accepted_when_required_header_is_valid()
+    {
+        // Arrange
+        var request = new HttpRequestMessage(
+            method: HttpMethod.Get,
+            requestUri: Path
+        );
+        request.Headers.TryAddWithoutValidation("x-required", Guid.NewGuid().ToString());
+        request.Headers.TryAddWithoutValidation("x-validate-only", "true");
+
+        // Act
+        var response = await Client.SendAsync(request);
+
+        // Assert
+        response.EnsureSuccessStatusCode();
+        Assert.Equal(HttpStatusCode.Accepted, response.StatusCode);
+    }
+
+    [Fact]
+    public async Task returns_bad_request_when_required_header_is_missing()
+    {
+        // Arrange
+        var request = new HttpRequestMessage(
+            method: HttpMethod.Get,
+            requestUri: Path
+        );
+        request.Headers.TryAddWithoutValidation("x-validate-only", "true");
+
+        // Act
+        var response = await Client.SendAsync(request);
+
+        // Assert
+        await response.EnsureErrorFor("x-required");
+    }
+    
+    [Theory]
+    [InlineData("not-a-guid")]
+    [InlineData("123")]
+    [InlineData("123-456-789")]
+    public async Task returns_bad_request_when_required_header_is_not_a_guid(string header)
+    {
+        // Arrange
+        var request = new HttpRequestMessage(
+            method: HttpMethod.Get,
+            requestUri: Path
+        );
+        request.Headers.TryAddWithoutValidation("x-required", header);
+        request.Headers.TryAddWithoutValidation("x-validate-only", "true");
+
+        // Act
+        var response = await Client.SendAsync(request);
+
+        // Assert
+        await response.EnsureErrorFor("x-required");
+    }
+}

--- a/test/A3.MinimalApiValidation.Tests/ApiIntegrationTests/ValidateOnlyFilter/Header/RequiredIntHeader.cs
+++ b/test/A3.MinimalApiValidation.Tests/ApiIntegrationTests/ValidateOnlyFilter/Header/RequiredIntHeader.cs
@@ -1,0 +1,79 @@
+namespace A3.MinimalApiValidation.Tests.ApiIntegrationTests.ValidateOnlyFilter.Header;
+
+using System.Net;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.Testing;
+using Microsoft.AspNetCore.Routing;
+
+public class RequiredIntHeader : TestBase
+{
+    public RequiredIntHeader(WebApplicationFactory<Program> factory) : base(factory)
+    {
+    }
+
+    protected override void AddTestEndpoint(IEndpointRouteBuilder app)
+    {
+        app.MapGet(Path, ([FromHeader(Name = "x-required")] int header) => Results.StatusCode(500)).WithValidateOnly();
+    }
+
+    [Theory]
+    [InlineData(1)]
+    [InlineData(2)]
+    [InlineData(123)]
+    public async Task returns_accepted_when_required_header_is_valid(int header)
+    {
+        // Arrange
+        var request = new HttpRequestMessage(
+            method: HttpMethod.Get,
+            requestUri: Path
+        );
+        request.Headers.TryAddWithoutValidation("x-required", header.ToString());
+        request.Headers.TryAddWithoutValidation("x-validate-only", "true");
+
+        // Act
+        var response = await Client.SendAsync(request);
+
+        // Assert
+        response.EnsureSuccessStatusCode();
+        Assert.Equal(HttpStatusCode.Accepted, response.StatusCode);
+    }
+
+    [Fact]
+    public async Task returns_bad_request_when_required_header_is_missing()
+    {
+        // Arrange
+        var request = new HttpRequestMessage(
+            method: HttpMethod.Get,
+            requestUri: Path
+        );
+        request.Headers.TryAddWithoutValidation("x-validate-only", "true");
+
+        // Act
+        var response = await Client.SendAsync(request);
+
+        // Assert
+        await response.EnsureErrorFor("x-required");
+    }
+
+    [Theory]
+    [InlineData("not-an-int")]
+    [InlineData("123-456-789")]
+    public async Task returns_bad_request_when_required_header_is_not_an_int(string header)
+    {
+        // Arrange
+        var request = new HttpRequestMessage(
+            method: HttpMethod.Get,
+            requestUri: Path
+        );
+        request.Headers.TryAddWithoutValidation("x-required", header);
+        request.Headers.TryAddWithoutValidation("x-validate-only", "true");
+
+        // Act
+        var response = await Client.SendAsync(request);
+
+        // Assert
+        await response.EnsureErrorFor("x-required");
+    }
+}

--- a/test/A3.MinimalApiValidation.Tests/ApiIntegrationTests/ValidateOnlyFilter/Header/RequiredStringHeader.cs
+++ b/test/A3.MinimalApiValidation.Tests/ApiIntegrationTests/ValidateOnlyFilter/Header/RequiredStringHeader.cs
@@ -1,0 +1,59 @@
+namespace A3.MinimalApiValidation.Tests.ApiIntegrationTests.ValidateOnlyFilter.Header;
+
+using System.Net;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.Testing;
+using Microsoft.AspNetCore.Routing;
+
+public class RequiredStringHeader : TestBase
+{
+    public RequiredStringHeader(WebApplicationFactory<Program> factory) : base(factory)
+    {
+    }
+
+    protected override void AddTestEndpoint(IEndpointRouteBuilder app)
+    {
+        app.MapGet(Path, ([FromHeader(Name = "x-required")] string header) => Results.StatusCode(500)).WithValidateOnly();
+    }
+
+    [Theory]
+    [InlineData("some value")]
+    [InlineData("some other value")]
+    [InlineData("something else 123")]
+    public async Task returns_accepted_when_required_header_is_valid(string header)
+    {
+        // Arrange
+        var request = new HttpRequestMessage(
+            method: HttpMethod.Get,
+            requestUri: Path
+        );
+        request.Headers.TryAddWithoutValidation("x-required", header);
+        request.Headers.TryAddWithoutValidation("x-validate-only", "true");
+
+        // Act
+        var response = await Client.SendAsync(request);
+
+        // Assert
+        response.EnsureSuccessStatusCode();
+        Assert.Equal(HttpStatusCode.Accepted, response.StatusCode);
+    }
+
+    [Fact]
+    public async Task returns_bad_request_when_required_header_is_missing()
+    {
+        // Arrange
+        var request = new HttpRequestMessage(
+            method: HttpMethod.Get,
+            requestUri: Path
+        );
+        request.Headers.TryAddWithoutValidation("x-validate-only", "true");
+
+        // Act
+        var response = await Client.SendAsync(request);
+
+        // Assert
+        await response.EnsureErrorFor("x-required");
+    }
+}

--- a/test/A3.MinimalApiValidation.Tests/ApiIntegrationTests/ValidateOnlyFilter/Query/RequiredDateTimeQueryParam.cs
+++ b/test/A3.MinimalApiValidation.Tests/ApiIntegrationTests/ValidateOnlyFilter/Query/RequiredDateTimeQueryParam.cs
@@ -1,0 +1,95 @@
+namespace A3.MinimalApiValidation.Tests.ApiIntegrationTests.ValidateOnlyFilter.Query;
+
+using System.Net;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.Testing;
+using Microsoft.AspNetCore.Routing;
+
+public class RequiredDateTimeQueryParam : TestBase
+{
+    public RequiredDateTimeQueryParam(WebApplicationFactory<Program> factory) : base(factory)
+    {
+    }
+
+    protected override void AddTestEndpoint(IEndpointRouteBuilder app)
+    {
+        app.MapGet(Path, ([FromQuery] DateTime query) => Results.StatusCode(500)).WithValidateOnly();
+    }
+
+    [Theory]
+    [InlineData("2022-02-22")]
+    [InlineData("2022-02-22T22:22:22")]
+    [InlineData("2022-02-22T22:22:22Z")]
+    [InlineData("2022-02-22T22:22:22.123")]
+    public async Task returns_accepted_when_required_query_param_is_valid(string query)
+    {
+        // Arrange
+        var request = new HttpRequestMessage(
+            method: HttpMethod.Get,
+            requestUri: $"{Path}?query={query}"
+        );
+        request.Headers.TryAddWithoutValidation("x-validate-only", "true");
+
+        // Act
+        var response = await Client.SendAsync(request);
+
+        // Assert
+        response.EnsureSuccessStatusCode();
+        Assert.Equal(HttpStatusCode.Accepted, response.StatusCode);
+    }
+
+    [Fact]
+    public async Task returns_bad_request_when_required_query_param_is_missing()
+    {
+        // Arrange
+        var request = new HttpRequestMessage(
+            method: HttpMethod.Get,
+            requestUri: $"{Path}"
+        );
+        request.Headers.TryAddWithoutValidation("x-validate-only", "true");
+
+        // Act
+        var response = await Client.SendAsync(request);
+
+        // Assert
+        await response.EnsureErrorFor("query");
+    }
+
+    [Fact]
+    public async Task returns_bad_request_when_required_query_param_is_empty()
+    {
+        // Arrange
+        var request = new HttpRequestMessage(
+            method: HttpMethod.Get,
+            requestUri: $"{Path}?query="
+        );
+        request.Headers.TryAddWithoutValidation("x-validate-only", "true");
+
+        // Act
+        var response = await Client.SendAsync(request);
+
+        // Assert
+        await response.EnsureErrorFor("query");
+    }
+
+    [Theory]
+    [InlineData("not-a-date")]
+    [InlineData("123-456")]
+    public async Task returns_bad_request_when_required_query_param_is_not_a_date(string query)
+    {
+        // Arrange
+        var request = new HttpRequestMessage(
+            method: HttpMethod.Get,
+            requestUri: $"{Path}?query={query}"
+        );
+        request.Headers.TryAddWithoutValidation("x-validate-only", "true");
+
+        // Act
+        var response = await Client.SendAsync(request);
+
+        // Assert
+        await response.EnsureErrorFor("query");
+    }
+}

--- a/test/A3.MinimalApiValidation.Tests/ApiIntegrationTests/ValidateOnlyFilter/Query/RequiredGuidQueryParam.cs
+++ b/test/A3.MinimalApiValidation.Tests/ApiIntegrationTests/ValidateOnlyFilter/Query/RequiredGuidQueryParam.cs
@@ -1,0 +1,94 @@
+namespace A3.MinimalApiValidation.Tests.ApiIntegrationTests.ValidateOnlyFilter.Query;
+
+using System.Net;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.Testing;
+using Microsoft.AspNetCore.Routing;
+
+public class RequiredGuidQueryParam : TestBase
+{
+    public RequiredGuidQueryParam(WebApplicationFactory<Program> factory) : base(factory)
+    {
+    }
+
+    protected override void AddTestEndpoint(IEndpointRouteBuilder app)
+    {
+        app.MapGet(Path, ([FromQuery] Guid query) => Results.StatusCode(500)).WithValidateOnly();
+    }
+
+    [Fact]
+    public async Task returns_accepted_when_required_query_param_is_valid()
+    {
+        // Arrange
+        var guid = Guid.NewGuid();
+        
+        var request = new HttpRequestMessage(
+            method: HttpMethod.Get,
+            requestUri: $"{Path}?query={guid}"
+        );
+        request.Headers.TryAddWithoutValidation("x-validate-only", "true");
+
+        // Act
+        var response = await Client.SendAsync(request);
+
+        // Assert
+        response.EnsureSuccessStatusCode();
+        Assert.Equal(HttpStatusCode.Accepted, response.StatusCode);
+    }
+
+    [Fact]
+    public async Task returns_bad_request_when_required_query_param_is_missing()
+    {
+        // Arrange
+        var request = new HttpRequestMessage(
+            method: HttpMethod.Get,
+            requestUri: $"{Path}"
+        );
+        request.Headers.TryAddWithoutValidation("x-validate-only", "true");
+
+        // Act
+        var response = await Client.SendAsync(request);
+
+        // Assert
+        await response.EnsureErrorFor("query");
+    }
+
+    [Fact]
+    public async Task returns_bad_request_when_required_query_param_is_empty()
+    {
+        // Arrange
+        var request = new HttpRequestMessage(
+            method: HttpMethod.Get,
+            requestUri: $"{Path}?query="
+        );
+        request.Headers.TryAddWithoutValidation("x-validate-only", "true");
+
+        // Act
+        var response = await Client.SendAsync(request);
+
+        // Assert
+        await response.EnsureErrorFor("query");
+    }
+
+    [Theory]
+    [InlineData("not-a-guid")]
+    [InlineData("123")]
+    [InlineData("123-456-789")]
+    public async Task returns_bad_request_when_required_query_param_is_not_a_guid(string query)
+    {
+        // Arrange
+        var request = new HttpRequestMessage(
+            method: HttpMethod.Get,
+            requestUri: $"{Path}?query={query}"
+        );
+        request.Headers.TryAddWithoutValidation("x-validate-only", "true");
+
+        // Act
+        var response = await Client.SendAsync(request);
+
+        // Assert
+        await response.EnsureErrorFor("query");
+    }
+}

--- a/test/A3.MinimalApiValidation.Tests/ApiIntegrationTests/ValidateOnlyFilter/Query/RequiredIntQueryParam.cs
+++ b/test/A3.MinimalApiValidation.Tests/ApiIntegrationTests/ValidateOnlyFilter/Query/RequiredIntQueryParam.cs
@@ -1,0 +1,94 @@
+namespace A3.MinimalApiValidation.Tests.ApiIntegrationTests.ValidateOnlyFilter.Query;
+
+using System.Net;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.Testing;
+using Microsoft.AspNetCore.Routing;
+
+public class RequiredIntQueryParam : TestBase
+{
+    public RequiredIntQueryParam(WebApplicationFactory<Program> factory) : base(factory)
+    {
+    }
+
+    protected override void AddTestEndpoint(IEndpointRouteBuilder app)
+    {
+        app.MapGet(Path, ([FromQuery] int query) => Results.StatusCode(500)).WithValidateOnly();
+    }
+
+    [Theory]
+    [InlineData(1)]
+    [InlineData(2)]
+    [InlineData(123)]
+    public async Task returns_accepted_when_required_query_param_is_valid(int query)
+    {
+        // Arrange
+        var request = new HttpRequestMessage(
+            method: HttpMethod.Get,
+            requestUri: $"{Path}?query={query}"
+        );
+        request.Headers.TryAddWithoutValidation("x-validate-only", "true");
+
+        // Act
+        var response = await Client.SendAsync(request);
+
+        // Assert
+        response.EnsureSuccessStatusCode();
+        Assert.Equal(HttpStatusCode.Accepted, response.StatusCode);
+    }
+
+    [Fact]
+    public async Task returns_bad_request_when_required_query_param_is_missing()
+    {
+        // Arrange
+        var request = new HttpRequestMessage(
+            method: HttpMethod.Get,
+            requestUri: $"{Path}"
+        );
+        request.Headers.TryAddWithoutValidation("x-validate-only", "true");
+
+        // Act
+        var response = await Client.SendAsync(request);
+
+        // Assert
+        await response.EnsureErrorFor("query");
+    }
+
+    [Fact]
+    public async Task returns_bad_request_when_required_query_param_is_empty()
+    {
+        // Arrange
+        var request = new HttpRequestMessage(
+            method: HttpMethod.Get,
+            requestUri: $"{Path}?query="
+        );
+        request.Headers.TryAddWithoutValidation("x-validate-only", "true");
+
+        // Act
+        var response = await Client.SendAsync(request);
+
+        // Assert
+        await response.EnsureErrorFor("query");
+    }
+    
+    [Theory]
+    [InlineData("not-an-int")]
+    [InlineData("123-456-789")]
+    public async Task returns_bad_request_when_required_query_param_is_not_an_int(string query)
+    {
+        // Arrange
+        var request = new HttpRequestMessage(
+            method: HttpMethod.Get,
+            requestUri: $"{Path}?query={query}"
+        );
+        request.Headers.TryAddWithoutValidation("x-validate-only", "true");
+
+        // Act
+        var response = await Client.SendAsync(request);
+
+        // Assert
+        await response.EnsureErrorFor("query");
+    }
+}

--- a/test/A3.MinimalApiValidation.Tests/ApiIntegrationTests/ValidateOnlyFilter/Query/RequiredStringQueryParam.cs
+++ b/test/A3.MinimalApiValidation.Tests/ApiIntegrationTests/ValidateOnlyFilter/Query/RequiredStringQueryParam.cs
@@ -1,0 +1,75 @@
+namespace A3.MinimalApiValidation.Tests.ApiIntegrationTests.ValidateOnlyFilter.Query;
+
+using System.Net;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.Testing;
+using Microsoft.AspNetCore.Routing;
+
+public class RequiredStringQueryParam : TestBase
+{
+    public RequiredStringQueryParam(WebApplicationFactory<Program> factory) : base(factory)
+    {
+    }
+
+    protected override void AddTestEndpoint(IEndpointRouteBuilder app)
+    {
+        app.MapGet(Path, ([FromQuery] string query) => Results.StatusCode(500)).WithValidateOnly();
+    }
+
+    [Theory]
+    [InlineData("value")]
+    [InlineData("some-other-value")]
+    [InlineData("something-else-123")]
+    public async Task returns_accepted_when_required_query_param_is_valid(string query)
+    {
+        // Arrange
+        var request = new HttpRequestMessage(
+            method: HttpMethod.Get,
+            requestUri: $"{Path}?query={query}"
+        );
+        request.Headers.TryAddWithoutValidation("x-validate-only", "true");
+
+        // Act
+        var response = await Client.SendAsync(request);
+
+        // Assert
+        response.EnsureSuccessStatusCode();
+        Assert.Equal(HttpStatusCode.Accepted, response.StatusCode);
+    }
+
+    [Fact]
+    public async Task returns_bad_request_when_required_query_param_is_missing()
+    {
+        // Arrange
+        var request = new HttpRequestMessage(
+            method: HttpMethod.Get,
+            requestUri: $"{Path}"
+        );
+        request.Headers.TryAddWithoutValidation("x-validate-only", "true");
+
+        // Act
+        var response = await Client.SendAsync(request);
+
+        // Assert
+        await response.EnsureErrorFor("query");
+    }
+
+    [Fact]
+    public async Task returns_ok_when_required_query_param_is_empty()
+    {
+        // Arrange
+        var request = new HttpRequestMessage(
+            method: HttpMethod.Get,
+            requestUri: $"{Path}?query="
+        );
+        request.Headers.TryAddWithoutValidation("x-validate-only", "true");
+
+        // Act
+        var response = await Client.SendAsync(request);
+
+        // Assert
+        response.EnsureSuccessStatusCode();
+    }
+}

--- a/test/A3.MinimalApiValidation.Tests/EndpointValidatorOptionsTests.cs
+++ b/test/A3.MinimalApiValidation.Tests/EndpointValidatorOptionsTests.cs
@@ -11,6 +11,7 @@ public class EndpointValidatorOptionsTests
             FallbackToDataAnnotations = false,
             JsonSerializerOptions = null,
             PreferExplicitRequestModelValidation = false,
+            ValidateOnlyHeader = "x-validate-only",
         };
 
         // Act


### PR DESCRIPTION
Adds an endpoint filter that allows the request to be validated but not executed when the `x-validate-only` header is present and set to `true`.

Example:
```csharp
app.MapPost("/test-body", ([FromBody] TestRecord test) => test).WithValidateOnly();
```

Request:
```http request
POST /test-body
Content-Type: application/json
x-validate-only: true

{
  "name": "John",
  "age": 30
}
```

Response:
```json
{
  "isValid": true,
  "message": "Request was validated but not processed.",
  "timestamp": "2024-11-12T14:30:26.3682090+00:00"
}