### PR TITLE
chore: Support added for date only in v1.0.0 (#72)

### DIFF
--- a/src/A3.MinimalApiValidation/Internal/Utils.cs
+++ b/src/A3.MinimalApiValidation/Internal/Utils.cs
@@ -124,7 +124,7 @@ internal static class Utils
             return false;
         }
 
-        if (type is {IsInterface: true, IsGenericType: true}
+        if (type is { IsInterface: true, IsGenericType: true }
             && type.GetGenericTypeDefinition() == typeof(IEnumerable<>))
         {
             firstUnderlyingType = type.GetGenericArguments()[0];
@@ -148,7 +148,7 @@ internal static class Utils
     {
         var results = new List<ValidationFailure>();
         var failedIndexes = new List<int>();
-        foreach (var item in collection.Select((v, i) => new {Index = i, Value = v}))
+        foreach (var item in collection.Select((v, i) => new { Index = i, Value = v }))
         {
             var itemResult = await (validator is null
                 ? ValidateDataAnnotationsAsync(item.Value, options)
@@ -174,7 +174,7 @@ internal static class Utils
         var didCast = TryCastValue(value, type, out var castValue, out var defaultValue);
         return didCast ? castValue : defaultValue;
     }
-    
+
     public static bool TryCastValue(string? value, Type type, out object? castValue, out object? defaultValue)
     {
         castValue = null;
@@ -184,10 +184,10 @@ internal static class Utils
         {
             return false;
         }
-        
+
         var (success, result, def) = parser(value);
         defaultValue = def;
-        
+
         if (success)
         {
             castValue = result;
@@ -197,7 +197,7 @@ internal static class Utils
         castValue = defaultValue;
         return false;
     }
-    
+
     private static Dictionary<Type, Func<string?, (bool Success, object? CastValue, object? DefaultValue)>> TypeParsers { get; } = new()
     {
         { typeof(bool), v => (bool.TryParse(v, out var result), result, false) },
@@ -214,6 +214,8 @@ internal static class Utils
         { typeof(decimal?), v => (decimal.TryParse(v, NumberStyles.Number, CultureInfo.InvariantCulture, out var result), result, null) },
         { typeof(DateTime), v => (DateTime.TryParse(v, CultureInfo.InvariantCulture, DateTimeStyles.None, out var result), result, default(DateTime)) },
         { typeof(DateTime?), v => (DateTime.TryParse(v, CultureInfo.InvariantCulture, DateTimeStyles.None, out var result), result, null) },
+        { typeof(DateOnly), v => (DateOnly.TryParse(v, CultureInfo.InvariantCulture, DateTimeStyles.None, out var result), result, default(DateOnly)) },
+        { typeof(DateOnly?), v => (DateOnly.TryParse(v, CultureInfo.InvariantCulture, DateTimeStyles.None, out var result), result, null) },
         { typeof(Guid), v => (Guid.TryParse(v, out var result), result, default(Guid)) },
         { typeof(Guid?), v => (Guid.TryParse(v, out var result), result, null) },
         { typeof(string), v => (true, v, default(string)) },

--- a/test/A3.MinimalApiValidation.Tests/ApiIntegrationTests/FromQueryBinder/FromQueryBinding.cs
+++ b/test/A3.MinimalApiValidation.Tests/ApiIntegrationTests/FromQueryBinder/FromQueryBinding.cs
@@ -1,7 +1,7 @@
 namespace A3.MinimalApiValidation.Tests.ApiIntegrationTests.FromQueryBinder;
 
 using System.Net.Http.Json;
-using A3.MinimalApiValidation.Binders;
+using Binders;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
@@ -24,11 +24,12 @@ public class FromQueryBinding : TestBase
         int Age,
         [property: FromQuery(Name = "has-cake")] bool HasCake,
         DateTime Time,
-        [property: FromQuery(Name = "user-id")]Guid Id,
+        DateOnly Date,
+        [property: FromQuery(Name = "user-id")] Guid Id,
         long? OptionalLong,
         string? OptionalString
     );
-    
+
     [Theory]
     [InlineData(null, null)]
     [InlineData(42L, "Hello")]
@@ -41,14 +42,16 @@ public class FromQueryBinding : TestBase
         var age = 42;
         var hasCake = true;
         var time = "2022-01-01T00:00:00Z";
+        var date = "2022-01-01";
         var id = "B6DFFA8C-AE7D-4C39-AFEF-7B11FECA6C65";
-        
+
         // Act
         var response = await Client.GetAsync($"{Path}" +
             $"?name={name}" +
             $"&age={age}" +
             $"&has-cake={hasCake}" +
             $"&time={time}" +
+            $"&date={date}" +
             $"&user-id={id}" +
             $"&optionalLong={optionalLong}" +
             $"&optionalString={optionalString}");
@@ -61,6 +64,7 @@ public class FromQueryBinding : TestBase
         Assert.Equal(age, result.Age);
         Assert.True(result.HasCake);
         Assert.Equal(DateTime.Parse(time), result.Time);
+        Assert.Equal(DateOnly.Parse(date), result.Date);
         Assert.Equal(Guid.Parse(id), result.Id);
         Assert.Equal(optionalLong, result.OptionalLong);
         Assert.Equal(optionalString ?? string.Empty, result.OptionalString);

--- a/test/A3.MinimalApiValidation.Tests/ApiIntegrationTests/FromQueryBinder/FromQueryListBinding.cs
+++ b/test/A3.MinimalApiValidation.Tests/ApiIntegrationTests/FromQueryBinder/FromQueryListBinding.cs
@@ -23,8 +23,9 @@ public class FromQueryListBinding : TestBase
         List<Guid> Ids,
         string[] Items,
         IEnumerable<int> Numbers,
-        IReadOnlyCollection<DateTime> Dates);
-    
+        IReadOnlyCollection<DateTime> Dates,
+        IReadOnlyCollection<DateOnly> OnlyDates);
+
     [Fact]
     public async Task properties_are_bound_correctly()
     {
@@ -38,6 +39,8 @@ public class FromQueryListBinding : TestBase
         var number2 = 73;
         var date1 = "2022-01-01T00:00:00Z";
         var date2 = "2022-01-02T00:00:00Z";
+        var dateOnly1 = "2022-01-01";
+        var dateOnly2 = "2022-01-02";
         
         // Act
         var response = await Client.GetAsync($"{Path}" +
@@ -45,7 +48,8 @@ public class FromQueryListBinding : TestBase
             $"&ids={id1}&ids={id2}" +
             $"&items={item1}&items={item2}" +
             $"&numbers={number1}&numbers={number2}" +
-            $"&dates={date1}&dates={date2}");
+            $"&dates={date1}&dates={date2}" +
+            $"&onlyDates={dateOnly1}&onlyDates={dateOnly2}");
 
         // Assert
         response.EnsureSuccessStatusCode();
@@ -64,5 +68,7 @@ public class FromQueryListBinding : TestBase
         Assert.Equal(2, result.Dates.Count);
         Assert.Equal(DateTime.Parse(date1), result.Dates.First());
         Assert.Equal(DateTime.Parse(date2), result.Dates.Last());
+        Assert.Equal(DateOnly.Parse(dateOnly1), result.OnlyDates.First());
+        Assert.Equal(DateOnly.Parse(dateOnly2), result.OnlyDates.Last());
     }
 }

--- a/test/A3.MinimalApiValidation.Tests/ApiIntegrationTests/OptionalProperties/OptionalDateOnlyHeader.cs
+++ b/test/A3.MinimalApiValidation.Tests/ApiIntegrationTests/OptionalProperties/OptionalDateOnlyHeader.cs
@@ -1,0 +1,74 @@
+namespace A3.MinimalApiValidation.Tests.ApiIntegrationTests.OptionalProperties;
+
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.Testing;
+using Microsoft.AspNetCore.Routing;
+
+public class OptionalDateOnlyHeader : TestBase
+{
+    public OptionalDateOnlyHeader(WebApplicationFactory<Program> factory) : base(factory)
+    {
+    }
+
+    protected override void AddTestEndpoint(IEndpointRouteBuilder app)
+    {
+        app.MapGet(Path, ([FromHeader(Name = "x-required")] DateOnly? header) => TypedResults.Ok());
+    }
+
+    [Theory]
+    [InlineData("2022-02-22")]
+    [InlineData("02/22/2022")]
+    public async Task returns_ok_when_optional_header_is_valid(string header)
+    {
+        // Arrange
+        var request = new HttpRequestMessage(
+            method: HttpMethod.Get,
+            requestUri: Path
+        );
+        request.Headers.TryAddWithoutValidation("x-required", header);
+
+        // Act
+        var response = await Client.SendAsync(request);
+
+        // Assert
+        response.EnsureSuccessStatusCode();
+    }
+
+    [Fact]
+    public async Task returns_ok_when_optional_header_is_missing()
+    {
+        // Arrange
+        var request = new HttpRequestMessage(
+            method: HttpMethod.Get,
+            requestUri: Path
+        );
+
+        // Act
+        var response = await Client.SendAsync(request);
+
+        // Assert
+        response.EnsureSuccessStatusCode();
+    }
+
+    [Theory]
+    [InlineData("not-a-date")]
+    [InlineData("123-456")]
+    [InlineData("2022-02-22T22:22:22Z")]
+    public async Task returns_bad_request_when_optional_header_is_not_a_date(string header)
+    {
+        // Arrange
+        var request = new HttpRequestMessage(
+            method: HttpMethod.Get,
+            requestUri: Path
+        );
+        request.Headers.TryAddWithoutValidation("x-required", header);
+
+        // Act
+        var response = await Client.SendAsync(request);
+
+        // Assert
+        await response.EnsureErrorFor("x-required");
+    }
+}

--- a/test/A3.MinimalApiValidation.Tests/ApiIntegrationTests/OptionalProperties/OptionalDateOnlyQueryParam.cs
+++ b/test/A3.MinimalApiValidation.Tests/ApiIntegrationTests/OptionalProperties/OptionalDateOnlyQueryParam.cs
@@ -1,0 +1,68 @@
+namespace A3.MinimalApiValidation.Tests.ApiIntegrationTests.OptionalProperties;
+
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.Testing;
+using Microsoft.AspNetCore.Routing;
+
+public class OptionalDateOnlyQueryParam : TestBase
+{
+    public OptionalDateOnlyQueryParam(WebApplicationFactory<Program> factory) : base(factory)
+    {
+    }
+
+    protected override void AddTestEndpoint(IEndpointRouteBuilder app)
+    {
+        app.MapGet(Path, ([FromQuery] DateOnly? query) => TypedResults.Ok());
+    }
+
+    [Theory]
+    [InlineData("2022-02-22")]
+    [InlineData("02/22/2022")]
+    public async Task returns_ok_when_optional_query_param_is_valid(string query)
+    {
+        // Arrange
+        // Act
+        var response = await Client.GetAsync($"{Path}?query={query}");
+
+        // Assert
+        response.EnsureSuccessStatusCode();
+    }
+
+    [Fact]
+    public async Task returns_ok_when_optional_query_param_is_missing()
+    {
+        // Arrange
+        // Act
+        var response = await Client.GetAsync($"{Path}");
+
+        // Assert
+        response.EnsureSuccessStatusCode();
+    }
+
+    [Fact]
+    public async Task returns_bad_request_when_optional_query_param_is_empty()
+    {
+        // Arrange
+        // Act
+        var response = await Client.GetAsync($"{Path}?query=");
+
+        // Assert
+        await response.EnsureErrorFor("query");
+    }
+
+    [Theory]
+    [InlineData("not-a-date")]
+    [InlineData("123-456")]
+    [InlineData("2022-02-22T22:22:22Z")]
+    public async Task returns_bad_request_when_optional_query_param_is_not_a_date(string query)
+    {
+        // Arrange
+        // Act
+        var response = await Client.GetAsync($"{Path}?query={query}");
+
+        // Assert
+        await response.EnsureErrorFor("query");
+    }
+}

--- a/test/A3.MinimalApiValidation.Tests/ApiIntegrationTests/RequiredProperties/RequiredDateOnlyHeader.cs
+++ b/test/A3.MinimalApiValidation.Tests/ApiIntegrationTests/RequiredProperties/RequiredDateOnlyHeader.cs
@@ -1,0 +1,74 @@
+namespace A3.MinimalApiValidation.Tests.ApiIntegrationTests.RequiredProperties;
+
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.Testing;
+using Microsoft.AspNetCore.Routing;
+
+public class RequiredDateOnlyHeader : TestBase
+{
+    public RequiredDateOnlyHeader(WebApplicationFactory<Program> factory) : base(factory)
+    {
+    }
+
+    protected override void AddTestEndpoint(IEndpointRouteBuilder app)
+    {
+        app.MapGet(Path, ([FromHeader(Name = "x-required")] DateOnly header) => TypedResults.Ok());
+    }
+
+    [Theory]
+    [InlineData("2022-02-22")]
+    [InlineData("02/22/2022")]
+    public async Task returns_ok_when_required_header_is_valid(string header)
+    {
+        // Arrange
+        var request = new HttpRequestMessage(
+            method: HttpMethod.Get,
+            requestUri: Path
+        );
+        request.Headers.TryAddWithoutValidation("x-required", header);
+
+        // Act
+        var response = await Client.SendAsync(request);
+
+        // Assert
+        response.EnsureSuccessStatusCode();
+    }
+
+    [Fact]
+    public async Task returns_bad_request_when_required_header_is_missing()
+    {
+        // Arrange
+        var request = new HttpRequestMessage(
+            method: HttpMethod.Get,
+            requestUri: Path
+        );
+
+        // Act
+        var response = await Client.SendAsync(request);
+
+        // Assert
+        await response.EnsureErrorFor("x-required");
+    }
+
+    [Theory]
+    [InlineData("not-a-date")]
+    [InlineData("123-456")]
+    [InlineData("2022-02-22T22:22:22Z")]
+    public async Task returns_bad_request_when_required_header_is_not_a_date(string header)
+    {
+        // Arrange
+        var request = new HttpRequestMessage(
+            method: HttpMethod.Get,
+            requestUri: Path
+        );
+        request.Headers.TryAddWithoutValidation("x-required", header);
+
+        // Act
+        var response = await Client.SendAsync(request);
+
+        // Assert
+        await response.EnsureErrorFor("x-required");
+    }
+}

--- a/test/A3.MinimalApiValidation.Tests/ApiIntegrationTests/RequiredProperties/RequiredDateOnlyQueryParam.cs
+++ b/test/A3.MinimalApiValidation.Tests/ApiIntegrationTests/RequiredProperties/RequiredDateOnlyQueryParam.cs
@@ -1,0 +1,68 @@
+namespace A3.MinimalApiValidation.Tests.ApiIntegrationTests.RequiredProperties;
+
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.Testing;
+using Microsoft.AspNetCore.Routing;
+
+public class RequiredDateOnlyQueryParam : TestBase
+{
+    public RequiredDateOnlyQueryParam(WebApplicationFactory<Program> factory) : base(factory)
+    {
+    }
+
+    protected override void AddTestEndpoint(IEndpointRouteBuilder app)
+    {
+        app.MapGet(Path, ([FromQuery] DateOnly query) => TypedResults.Ok());
+    }
+
+    [Theory]
+    [InlineData("2022-02-22")]
+    [InlineData("02/22/2022")]
+    public async Task returns_ok_when_required_query_param_is_valid(string query)
+    {
+        // Arrange
+        // Act
+        var response = await Client.GetAsync($"{Path}?query={query}");
+
+        // Assert
+        response.EnsureSuccessStatusCode();
+    }
+
+    [Fact]
+    public async Task returns_bad_request_when_required_query_param_is_missing()
+    {
+        // Arrange
+        // Act
+        var response = await Client.GetAsync($"{Path}");
+
+        // Assert
+        await response.EnsureErrorFor("query");
+    }
+
+    [Fact]
+    public async Task returns_bad_request_when_required_query_param_is_empty()
+    {
+        // Arrange
+        // Act
+        var response = await Client.GetAsync($"{Path}?query=");
+
+        // Assert
+        await response.EnsureErrorFor("query");
+    }
+
+    [Theory]
+    [InlineData("not-a-date")]
+    [InlineData("123-456")]
+    [InlineData("2022-02-22T22:22:22Z")]
+    public async Task returns_bad_request_when_required_query_param_is_not_a_date(string query)
+    {
+        // Arrange
+        // Act
+        var response = await Client.GetAsync($"{Path}?query={query}");
+
+        // Assert
+        await response.EnsureErrorFor("query");
+    }
+}


### PR DESCRIPTION
Added DateOnly to dictionary to support DateOnly params with appropriate tests